### PR TITLE
Add Support for Directional Attenuation

### DIFF
--- a/scripts/cardinal.js
+++ b/scripts/cardinal.js
@@ -24,7 +24,7 @@ module.exports = (function() {
 	};
 
 	// Enum of all cardinal aligned rotations - could do clever maths but this is more readable and probably more performant
-	// In the form of YZ localY -> global (with x implicit and dependent on handedness), e.g. LeftBack => local up = global left, local forward = global back
+	// In the form of YZ local -> global (with x implicit and dependent on handedness), e.g. LeftBack => local up = global left, local forward = global back
 	// In order of a given y direction, rotating then rotating clockwise around local y, implicit right direction in comment
 	let Rotation = exports.Rotation = {
 		// No Rotations, local up = global up
@@ -198,6 +198,124 @@ module.exports = (function() {
 				return Direction.down;
 			default:
 				return Direction.forward;
+		}
+	};
+
+	exports.getAxis = (axis, rotation) => {
+		switch (axis) {
+			case 0:
+				return exports.getXAxis(rotation);
+			case 1:
+				return exports.getYAxis(rotation);
+			case 2:
+				return exports.getZAxis(rotation);
+			default:
+				return axis;
+		}
+	};
+	
+	// Returns the index of the local X axis in global space
+	exports.getXAxis = (rotation) => {
+		switch(rotation) {
+			case Rotation.upForward:
+			case Rotation.downForward:
+			case Rotation.upBack:
+			case Rotation.downBack:
+			case Rotation.forwardUp:
+			case Rotation.backUp:
+			case Rotation.forwardDown:
+			case Rotation.backDown:
+				return 0;
+			case Rotation.leftForward:
+			case Rotation.rightForward:
+			case Rotation.leftBack:
+			case Rotation.rightBack:
+			case Rotation.forwardLeft:
+			case Rotation.backLeft:
+			case Rotation.forwardRight:
+			case Rotation.backRight:
+				return 1;
+			case Rotation.upLeft:
+			case Rotation.downLeft:
+			case Rotation.upRight:
+			case Rotation.downRight:
+			case Rotation.leftUp:
+			case Rotation.rightUp:
+			case Rotation.leftDown:
+			case Rotation.rightDown:
+				return 2;
+			default:
+				return 0;
+		}
+	};
+
+	// Returns the index of the local Y axis in global space
+	exports.getYAxis = (rotation) => {
+		switch (rotation) {
+			case Rotation.upForward:
+			case Rotation.upRight:
+			case Rotation.upBack:
+			case Rotation.upLeft:
+			case Rotation.downForward:
+			case Rotation.downLeft:
+			case Rotation.downBack:
+			case Rotation.downRight:
+				return 1;
+			case Rotation.leftBack:
+			case Rotation.leftDown:
+			case Rotation.leftForward:
+			case Rotation.leftUp:
+			case Rotation.rightBack:
+			case Rotation.rightDown:
+			case Rotation.rightForward:
+			case Rotation.rightUp:
+				return 0;
+			case Rotation.forwardDown:
+			case Rotation.forwardLeft:
+			case Rotation.forwardRight:
+			case Rotation.forwardUp:
+			case Rotation.backDown:
+			case Rotation.backLeft:
+			case Rotation.backRight:
+			case Rotation.backUp:
+				return 2;
+			default:
+				return 1;
+		}
+	};
+
+	// Returns the index of the local Z axis in global space
+	exports.getZAxis = (rotation) => {
+		switch(rotation) {
+			case Rotation.upForward:
+			case Rotation.downForward:
+			case Rotation.leftForward:
+			case Rotation.rightForward:
+			case Rotation.upBack:
+			case Rotation.downBack:
+			case Rotation.leftBack:
+			case Rotation.rightBack:
+				return 2;
+			case Rotation.upLeft:
+			case Rotation.downLeft:
+			case Rotation.forwardLeft:
+			case Rotation.backLeft:
+			case Rotation.upRight:
+			case Rotation.downRight:
+			case Rotation.forwardRight:
+			case Rotation.backRight:
+				return 0;
+			case Rotation.forwardUp:
+			case Rotation.backUp:
+			case Rotation.leftUp:
+			case Rotation.rightUp:
+			case Rotation.forwardDown:
+			case Rotation.backDown:
+			case Rotation.leftDown:
+			case Rotation.rightDown:
+				return 1;
+			default:
+				return 2;
 		}
 	};
 

--- a/scripts/lighting.js
+++ b/scripts/lighting.js
@@ -111,6 +111,10 @@ module.exports = (function(){
 	};
 
 	let buildAdjacentLightQueue = function(queue, vorld, x, y, z) {
+		if (getBlockLight(vorld, x, y, z)) {
+			// Sort of hack, to cope with removal of attenuating blocks
+			queue.push(x, y, z);
+		}
 		if (getBlockLight(vorld, x + 1, y, z)) {
 			queue.push(x + 1, y, z);
 		}
@@ -132,6 +136,10 @@ module.exports = (function(){
 	};
 
 	let buildAdjacentSunlightQueue = function(queue, vorld, x, y, z) {
+		if (getBlockSunlight(vorld, x, y, z)) {
+			// Sort of hack, to cope with removal of attenuating blocks
+			queue.push(x, y, z);
+		}
 		if (getBlockSunlight(vorld, x + 1, y, z)) {
 			queue.push(x + 1, y, z);
 		}
@@ -307,7 +315,7 @@ module.exports = (function(){
 				if (isSunlight && attenuation == 1 && light == 15) {
 					lightY = 15;
 				}
-				if (trySetLightForBlock(vorld, pos[0], pos[1] - 1, pos[2], lightY, isSunlight)) {
+				if (trySetLightForBlock(vorld, pos[0], pos[1] - 1, pos[2], lightY, isSunlight)) { 
 					queue.push(pos[0], pos[1] - 1, pos[2]);
 				}
 			}

--- a/scripts/lighting.js
+++ b/scripts/lighting.js
@@ -1,4 +1,5 @@
 const BlockConfig = require('./blockConfig');
+const Cardinal = require('./cardinal');
 const Chunk = require('./chunk');
 const World = require('./world');
 const Maths = require('./maths');
@@ -12,11 +13,17 @@ module.exports = (function(){
 	let removalQueue = VectorQueue.create();
 
 	// Definition Property Helpers
-	let getBlockAttenuation = function(vorld, x, y, z) {
+	let getBlockAttenuation = function(vorld, axis, x, y, z) {
 		let block = World.getBlock(vorld, x, y, z);
 		let def = BlockConfig.getBlockTypeDefinition(vorld, block);
-		if (def && def.attenuation) {
-			return def.attenuation;
+		if (def) {
+			if (def.directionalAttenuation) {
+				let globalAxis = Cardinal.getAxis(axis, World.getBlockRotation(vorld, x, y, z));
+				return def.directionalAttenuation[globalAxis];
+			}
+			if (def.attenuation) {
+				return def.attenuation;
+			}
 		}
 		return 1;
 	}
@@ -278,45 +285,58 @@ module.exports = (function(){
 		// * Check adjacency when filling sunlight horizontally, < 14 to prevent repeated fills into the space
 		// * Use heap instead of queue (prioritise blocks with highest sunlight to set)
 		//   the insert cost may outweigh the reduction in propogation
+		// * Dedicated path for if the block doesn't have directional attenuation to avoid repeated
+		//   calls to getBlockAttenuation
 		while (queue.length) {
 			let pos = queue.pop();
-			let attenuation = getBlockAttenuation(vorld, pos[0], pos[1], pos[2]);
 			let light = !isSunlight ? getBlockLight(vorld, pos[0], pos[1], pos[2]) : getBlockSunlight(vorld, pos[0], pos[1], pos[2]);
-			light -= attenuation;
 
-			// Sunlight doesn't attenuate as it goes down
-			let downLight = light;
-			if (isSunlight && attenuation == 1 && light + attenuation == 15) {
-				downLight = 15;
-			}
-
-			// TODO: Get directional opacity vector, values 0 or 1 - transform by rotation and each axis as appropriate before propogating light
 			// Consider - we could probably store propogation direction histories in our queue - and then simulate bounces better than just flood fill
 
+			// Y Axis
+			let attenuation = getBlockAttenuation(vorld, 1, pos[0], pos[1], pos[2]);
+			let lightY = light - attenuation;
+
 			// Note: Only pushes when new light for block is greater than old value
-			if (light > 0) { 
-				if (trySetLightForBlock(vorld, pos[0], pos[1] + 1, pos[2], light, isSunlight)) {
+
+			if (lightY > 0) { 
+				if (trySetLightForBlock(vorld, pos[0], pos[1] + 1, pos[2], lightY, isSunlight)) {
 					queue.push(pos[0], pos[1] + 1, pos[2]);
 				}
-				if (trySetLightForBlock(vorld, pos[0], pos[1] - 1, pos[2], downLight, isSunlight)) {
+				// Sunlight doesn't attenuate as it goes down
+				if (isSunlight && attenuation == 1 && light == 15) {
+					lightY = 15;
+				}
+				if (trySetLightForBlock(vorld, pos[0], pos[1] - 1, pos[2], lightY, isSunlight)) {
 					queue.push(pos[0], pos[1] - 1, pos[2]);
 				}
-				// For Sunlight - don't consider horizontally adjacent blocks which will be filled with sunlight
-				// at some point (although they may not have been yet) 
+			}
+
+			// NOTE: For Sunlight - don't consider horizontally adjacent blocks which will be filled with sunlight
+			// at some point (although they may not have been yet).
+			// I.e. only fill blocks below the highest block y in that x, z position.
+
+			// X Axis
+			let lightX = light - getBlockAttenuation(vorld, 0, pos[0], pos[1], pos[2]);
+			if (lightX > 0) {
 				if ((!isSunlight || World.getHighestBlockY(vorld, pos[0] + 1, pos[2]) > pos[1])
-					&& trySetLightForBlock(vorld, pos[0] + 1, pos[1], pos[2], light, isSunlight)) {
+					&& trySetLightForBlock(vorld, pos[0] + 1, pos[1], pos[2], lightX, isSunlight)) {
 					queue.push(pos[0] + 1, pos[1], pos[2]);
 				}
 				if ((!isSunlight || World.getHighestBlockY(vorld, pos[0] - 1, pos[2]) > pos[1])
-					&& trySetLightForBlock(vorld, pos[0] - 1, pos[1], pos[2], light, isSunlight)) {
+					&& trySetLightForBlock(vorld, pos[0] - 1, pos[1], pos[2], lightX, isSunlight)) {
 					queue.push(pos[0] - 1, pos[1], pos[2]);
 				}
+			}
+
+			let lightZ = light - getBlockAttenuation(vorld, 0, pos[0], pos[1], pos[2]);
+			if (lightZ > 0) {
 				if ((!isSunlight || World.getHighestBlockY(vorld, pos[0], pos[2] + 1) > pos[1])
-					&& trySetLightForBlock(vorld, pos[0], pos[1], pos[2] + 1, light, isSunlight)) {
+					&& trySetLightForBlock(vorld, pos[0], pos[1], pos[2] + 1, lightZ, isSunlight)) {
 					queue.push(pos[0], pos[1], pos[2] + 1);
 				}
 				if ((!isSunlight || World.getHighestBlockY(vorld, pos[0], pos[2] - 1) > pos[1])
-					&& trySetLightForBlock(vorld, pos[0], pos[1], pos[2] - 1, light, isSunlight)) {
+					&& trySetLightForBlock(vorld, pos[0], pos[1], pos[2] - 1, lightZ, isSunlight)) {
 					queue.push(pos[0], pos[1], pos[2] - 1);
 				}
 			}

--- a/scripts/meshing/mesher.js
+++ b/scripts/meshing/mesher.js
@@ -105,9 +105,13 @@ module.exports = (function(){
 		aov[0] = (Maths.approximately(vertex[0], Math.round(vertex[0]), 0.0001)) ? Math.round(2 * (vertex[0] - i - 0.5)) : 0;
 		aov[1] = (Maths.approximately(vertex[1], Math.round(vertex[1]), 0.0001)) ? Math.round(2 * (vertex[1] - j - 0.5)) : 0;
 		aov[2] = (Maths.approximately(vertex[2], Math.round(vertex[2]), 0.0001)) ? Math.round(2 * (vertex[2] - k - 0.5)) : 0;
+		// ^^ the values that come out of this will be -1, 0, 1 depending on if at integer position, anywhere mid block, or at integer position
 		let adj = 0, side0 = 0, side1 = 0, corner = 0;
 		switch(direction)
 		{
+			// TODO: We need to adjust this for (directional) light attenutation of the block in question
+			// see what's happening with half blocks - presumably only if at integer position, i.e. if aov is not 0
+			// can't just do it in the delegate because the direction is important
 			case Cardinal.Direction.up:
 			case Cardinal.Direction.down:
 				adj = getLightDelegate(vorld, chunkI, chunkJ, chunkK, i, j + aov[1], k) || 0;
@@ -118,7 +122,7 @@ module.exports = (function(){
 					// If no light at side0 and side1 they may be opaque in which case we should ignore any light value from corner
 					let x = chunkI * vorld.chunkSize + i, y = chunkJ * vorld.chunkSize + j, z = chunkK * vorld.chunkSize + k;
 					if (Vorld.isBlockOpaque(vorld, x + aov[0], y + aov[1], z) 
-						&& Vorld.isBlockOpaque(vorld, x, y + aov[1], z + aov[2])) {
+						&& Vorld.isBlockOpaque(vorld, x, y + aov[1], z + aov[2])) { // this will need to also check for attenutation? 
 						corner = 0;
 					}
 				}

--- a/scripts/world.js
+++ b/scripts/world.js
@@ -69,13 +69,23 @@ module.exports = (function() {
 		return null;
 	};
 
-	exports.getBlockRotation = function(vorld, x, y, z) {
-		let [ chunkI, chunkJ, chunkK, blockI, blockJ, blockK ] = Utils.getIndices(vorld.chunkSize, x, y, z);
+	// Assumes indices are valid
+	let getBlockRotationByIndex = function(vorld, blockI, blockJ, blockK, chunkI, chunkJ, chunkK) {
 		let chunk = exports.getChunk(vorld, chunkI, chunkJ, chunkK);
 		if (chunk) {
 			return Chunk.getBlockRotation(chunk, blockI, blockJ, blockK);
 		}
 		return null;
+	};
+
+	exports.getBlockRotation = function(vorld, x, y, z) {
+		let [ chunkI, chunkJ, chunkK, blockI, blockJ, blockK ] = Utils.getIndices(vorld.chunkSize, x, y, z);
+		return getBlockRotationByIndex(vorld, blockI, blockJ, blockK, chunkI, chunkJ, chunkK);
+	}
+
+	exports.getBlockRotationByIndex = function(vorld, blockI, blockJ, blockK, chunkI, chunkJ, chunkK) {
+		[ chunkI, chunkJ, chunkK, blockI, blockJ, blockK ] = Utils.adjustChunkIndices(vorld.chunkSize, chunkI, chunkJ, chunkK, blockI, blockJ, blockK);
+		return getBlockRotationByIndex(vorld, blockI, blockJ, blockK, chunkI, chunkJ, chunkK);
 	}
 
 	// Assumes valid indicies


### PR DESCRIPTION
This required changes to light propagation - relatively trivial - but also to the mesher's light bake. 

I'm honestly not certain if the implementation is entirely correct, however it does block light through half-block if they are configured as such and prevents bleeding through.

However it also darkens the top of an array of half-block even when in direct downward sunlight which it should not. However this is bug is subtle enough, and the improvement to allowing half-blocks to block light propagation valuable enough that I'm going to merge as is.